### PR TITLE
add prometheus-trace-etl

### DIFF
--- a/jcommon/prometheus/pom.xml
+++ b/jcommon/prometheus/pom.xml
@@ -19,6 +19,8 @@
 		<module>prometheus-redis</module>
         <module>prometheus-starter</module>
 		<module>prometheus-metrics</module>
+		<module>prometheus-metrics</module>
+		<module>prometheus-trace-etl</module>
     </modules>
 
     <properties>

--- a/jcommon/prometheus/prometheus-trace-etl/pom.xml
+++ b/jcommon/prometheus/prometheus-trace-etl/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>run.mone</groupId>
+        <artifactId>prometheus</artifactId>
+        <version>0.0.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>prometheus-trace-etl</artifactId>
+    <version>${prometheus-all.version}</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>run.mone</groupId>
+                <artifactId>codecheck-maven-plugin</artifactId>
+                <version>1.4-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>pmd</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.10.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.1.7</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/Metrics.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/Metrics.java
@@ -1,0 +1,107 @@
+package com.xiaomi.youpin.prometheus.client;
+
+import com.xiaomi.youpin.prometheus.client.binder.ClassLoaderMetricsReduced;
+import com.xiaomi.youpin.prometheus.client.binder.JvmGcMetricsReduced;
+import com.xiaomi.youpin.prometheus.client.binder.JvmMemoryMetricsReduced;
+import com.xiaomi.youpin.prometheus.client.binder.JvmThreadMetricsReduced;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+
+/**
+ * @author zhangxiaowei
+ */
+@Slf4j
+public class Metrics {
+
+    public MetricsManager gMetricsMgr;
+    /**
+     * group+service形成namespace标识
+     */
+    public static final String GROUP = "group";
+    public static final String SERVICE = "service";
+    public static final String LABEL_TRACE_ID = "traceId";
+    public static final String APPLICATION = "application";
+
+    private static class LazyHolder {
+        private static final Metrics ins = new Metrics();
+    }
+
+
+    public void init(String group,String service) {
+        this.init(group,service,false);
+    }
+
+    public void init(String group,String service, boolean jvmReduced){
+        setGroup(group);
+        setService(service);
+        Prometheus.REGISTRY.config().commonTags(APPLICATION, Prometheus.constLabels.get(Metrics.SERVICE));
+        if(jvmReduced){
+            new ClassLoaderMetricsReduced().bindTo(Prometheus.REGISTRY);
+            new JvmMemoryMetricsReduced().bindTo(Prometheus.REGISTRY);
+            new JvmGcMetricsReduced().bindTo(Prometheus.REGISTRY);
+            new ProcessorMetrics().bindTo(Prometheus.REGISTRY);
+            new JvmThreadMetricsReduced().bindTo(Prometheus.REGISTRY);
+            new UptimeMetrics().bindTo(Prometheus.REGISTRY);
+            new FileDescriptorMetrics().bindTo(Prometheus.REGISTRY);
+        }else{
+            new ClassLoaderMetrics().bindTo(Prometheus.REGISTRY);
+            new JvmMemoryMetrics().bindTo(Prometheus.REGISTRY);
+            new JvmGcMetrics().bindTo(Prometheus.REGISTRY);
+            new ProcessorMetrics().bindTo(Prometheus.REGISTRY);
+            new JvmThreadMetrics().bindTo(Prometheus.REGISTRY);
+            new UptimeMetrics().bindTo(Prometheus.REGISTRY);
+            new FileDescriptorMetrics().bindTo(Prometheus.REGISTRY);
+        }
+    }
+
+
+    //获取唯一可用的对象
+    public static Metrics getInstance() {
+        return LazyHolder.ins;
+    }
+
+    public void setGroup(String group) {
+        Prometheus.constLabels.put(GROUP, group);
+    }
+
+    public void setService(String service) {
+        Prometheus.constLabels.put(SERVICE, service);
+    }
+
+    public static double[] DEFAULT_LATENCY_BUCKETS =
+            new double[]{.01, .05, 1, 5, 7.5, 10, 25, 50, 100, 200, 500, 1000,1500,2000,3000,4000,5000};
+
+    private Metrics() {
+        Prometheus.constLabels = new HashMap<>();
+        gMetricsMgr = new Prometheus();
+    }
+
+    public XmCounter newCounter(String metricName, String... labelNames) {
+        try {
+            return gMetricsMgr.newCounter(metricName, labelNames);
+        } catch (Throwable throwable) {
+            log.warn(throwable.getMessage());
+            return null;
+        }
+    }
+
+    public XmGauge newGauge(String metricName, String... labelNames) {
+        return gMetricsMgr.newGauge(metricName, labelNames);
+    }
+
+    public XmHistogram newHistogram(String metricName, double[] buckets, String... labelNames) {
+        if (buckets != null && buckets.length > 0) {
+            return gMetricsMgr.newHistogram(metricName, buckets, labelNames);
+        }
+        return gMetricsMgr.newHistogram(metricName, DEFAULT_LATENCY_BUCKETS, labelNames);
+    }
+
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/MetricsManager.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/MetricsManager.java
@@ -1,0 +1,36 @@
+package com.xiaomi.youpin.prometheus.client;
+/**
+ * @author zhangxiaowei
+ */
+public interface MetricsManager {
+     /**
+      * 使用Counter打点
+      *
+      * @param metricName 指标名
+      * @param labelNames 标签名
+      * @return XMCounter
+      */
+
+     XmCounter newCounter(String metricName, String... labelNames);
+
+     /**
+      * 使用Gauge打点
+      *
+      * @param metricName 指标名
+      * @param labelNames 标签名
+      * @return XMGauge
+      */
+
+     XmGauge newGauge(String metricName, String... labelNames);
+
+     /**
+      * 使用Histogram打点
+      *
+      * @param metricName 指标名
+      * @param buckets    存储桶
+      * @param labelNames 标签名
+      * @return XMHistogram
+      */
+
+     XmHistogram newHistogram(String metricName, double[] buckets, String... labelNames);
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/Prometheus.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/Prometheus.java
@@ -1,0 +1,166 @@
+package com.xiaomi.youpin.prometheus.client;
+
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.*;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author zhangxiaowei
+ */
+@Slf4j
+public class Prometheus implements MetricsManager{
+
+   public static final int CONST_LABELS_NUM = 2;
+   public static final PrometheusMeterRegistry REGISTRY = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+   public static Map<String, String> constLabels;
+   public Map<String, Object> prometheusMetrics;
+   public Map<String,Object> prometheusTypeMetrics;
+
+   private byte[] lock = new byte[0];
+   private byte[] typeLock = new byte[0];
+
+   public Prometheus() {
+      this.prometheusMetrics = new ConcurrentHashMap<>();
+      this.prometheusTypeMetrics = new ConcurrentHashMap<>();
+   }
+
+   @Override
+   public XmCounter newCounter(String metricName, String... labelName) {
+      if (prometheusTypeMetrics.containsKey(metricName)) {
+         return (XmCounter) prometheusTypeMetrics.get(metricName);
+      }
+      synchronized (typeLock) {
+         PrometheusCounter prometheusCounter = new PrometheusCounter(getCounter(metricName, labelName), labelName, null);
+         prometheusTypeMetrics.put(metricName,prometheusCounter);
+         return prometheusCounter;
+      }
+   }
+
+   @Override
+   public XmGauge newGauge(String metricName, String... labelName) {
+      if (prometheusTypeMetrics.containsKey(metricName)) {
+         return (XmGauge) prometheusTypeMetrics.get(metricName);
+      }
+      synchronized (typeLock) {
+         PrometheusGauge prometheusGauge = new PrometheusGauge(getGauge(metricName, labelName), labelName, null);
+         prometheusTypeMetrics.put(metricName,prometheusGauge);
+         return prometheusGauge;
+      }
+
+   }
+
+   @Override
+   public XmHistogram newHistogram(String metricName, double[] bucket, String... labelNames) {
+      if (prometheusTypeMetrics.containsKey(metricName)) {
+         return (XmHistogram) prometheusTypeMetrics.get(metricName);
+      }
+      synchronized (typeLock) {
+         PrometheusHistogram prometheusHistogram = new PrometheusHistogram(getHistogram(metricName, bucket, labelNames), labelNames, null);
+         prometheusTypeMetrics.put(metricName,prometheusHistogram);
+         return prometheusHistogram;
+      }
+   }
+
+   public Counter getCounter(String metricName, String... labelName) {
+      if (constLabels.size() != Prometheus.CONST_LABELS_NUM) {
+         return null;
+      }
+      try {
+         //如果有直接返回
+         if (prometheusMetrics.containsKey(metricName)) {
+            //log.debug("already have metric:" + metricName);
+            return (Counter) prometheusMetrics.get(metricName);
+         }
+
+         synchronized (lock) {
+            //没有需要先注册一个
+            List<String> mylist = new ArrayList<>(Arrays.asList(labelName));
+//            mylist.add(Metrics.APPLICATION);
+            String[] finalValue = mylist.toArray(new String[mylist.size()]);
+            String nameSpace = constLabels.get(Metrics.GROUP) + ("".equals(constLabels.get(Metrics.SERVICE))?"":"_"+constLabels.get(Metrics.SERVICE));
+            Counter newCounter = Counter.build()
+                    .name(metricName)
+                    .namespace(nameSpace)
+                    .labelNames(finalValue)
+                    .help(metricName)
+                    .register();
+
+            prometheusMetrics.put(metricName, newCounter);
+            return newCounter;
+         }
+      } catch (Throwable throwable) {
+         log.warn(metricName+" get counter error",throwable);
+         return null;
+      }
+   }
+
+   public Gauge getGauge(String metricName, String... labelName) {
+      if (constLabels.size() != Prometheus.CONST_LABELS_NUM) {
+         return null;
+      }
+      try {
+         //如果有直接返回
+         if (prometheusMetrics.containsKey(metricName)) {
+           // log.debug("already have metric:" + metricName);
+            return (Gauge) prometheusMetrics.get(metricName);
+         }
+         synchronized (lock) {
+            //没有需要先注册一个
+            List<String> mylist = new ArrayList<>(Arrays.asList(labelName));
+//            mylist.add(Metrics.APPLICATION);
+            String[] finalValue = mylist.toArray(new String[mylist.size()]);
+            String nameSpace = constLabels.get(Metrics.GROUP) + ("".equals(constLabels.get(Metrics.SERVICE))?"":"_"+constLabels.get(Metrics.SERVICE));
+            Gauge newGauge = Gauge.build()
+                    .name(metricName)
+                    .namespace(nameSpace)
+                    .labelNames(finalValue)
+                    .help(metricName)
+                    .register();
+
+            prometheusMetrics.put(metricName, newGauge);
+            return newGauge;
+         }
+      } catch (Throwable throwable) {
+         log.warn(metricName+" get gauge error",throwable);
+         return null;
+      }
+
+   }
+
+   public Histogram getHistogram(String metricName, double[] buckets, String... labelNames) {
+      if (constLabels.size() != Prometheus.CONST_LABELS_NUM) {
+         return null;
+      }
+      try {
+         //如果有直接返回
+         if (prometheusMetrics.containsKey(metricName)) {
+           // log.debug("already have metric:" + metricName);
+            return (Histogram) prometheusMetrics.get(metricName);
+         }
+
+         synchronized (lock) {
+            //没有需要注册一个
+            List<String> mylist = new ArrayList<>(Arrays.asList(labelNames));
+//            mylist.add(Metrics.APPLICATION);
+            String[] finalValue = mylist.toArray(new String[mylist.size()]);
+            String nameSpace = constLabels.get(Metrics.GROUP) + ("".equals(constLabels.get(Metrics.SERVICE))?"":"_"+constLabels.get(Metrics.SERVICE));
+            Histogram newHistogram = Histogram.build()
+                    .buckets(buckets)
+                    .name(metricName)
+                    .namespace(nameSpace)
+                    .labelNames(finalValue)
+                    .help(metricName)
+                    .register();
+            prometheusMetrics.put(metricName, newHistogram);
+            return newHistogram;
+         }
+      } catch (Throwable throwable) {
+         log.warn(metricName+" get histogram error",throwable);
+         return null;
+      }
+   }
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/PrometheusCounter.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/PrometheusCounter.java
@@ -1,0 +1,65 @@
+package com.xiaomi.youpin.prometheus.client;
+
+import io.prometheus.client.Counter;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author zhangxiaowei
+ */
+@Slf4j
+public class PrometheusCounter implements XmCounter {
+
+    public String[] labelValues;
+
+    public Counter myCounter;
+
+    public String[] labelNames;
+
+    public PrometheusCounter(Counter cb, String[] lns, String[] lvs) {
+        this.myCounter = cb;
+        this.labelNames = lns;
+        this.labelValues = lvs;
+    }
+
+    public PrometheusCounter() {
+
+    }
+
+    @Override
+    public XmCounter with(String... labelValues) {
+        try {
+            if (this.labelNames.length != labelValues.length) {
+                log.warn("Incorrect numbers of labels : " + myCounter.describe().get(0).name + " labelName: " + this.labelNames.length + " labelValues: " + labelValues.length + "{} {}", Arrays.toString(this.labelNames), Arrays.toString(labelValues));
+                return new PrometheusCounter();
+            }
+            return this;
+        } catch (Exception e) {
+            log.warn("prometheus counter with error",e);
+            return null;
+        }
+    }
+
+    @Override
+    public void add(double delta, String... labelValues) {
+        this.add(Prometheus.constLabels.get(Metrics.SERVICE),delta,labelValues);
+    }
+
+    @Override
+    public void add(String service, double delta, String... labelValues) {
+        List<String> mylist = new ArrayList<>(Arrays.asList(labelValues));
+//        mylist.add(service);
+        // mylist.add(traceId);
+        String[] finalValue = mylist.toArray(new String[mylist.size()]);
+        try {
+            this.myCounter.labels(finalValue).inc(delta);
+        } catch (Exception e) {
+            log.warn("prometheus counter add error",e);
+        }
+    }
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/PrometheusGauge.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/PrometheusGauge.java
@@ -1,0 +1,79 @@
+package com.xiaomi.youpin.prometheus.client;
+
+import io.prometheus.client.Gauge;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author zhangxiaowei
+ */
+@Slf4j
+public class PrometheusGauge implements XmGauge {
+
+    public Gauge myGauge;
+    public String[] labelNames;
+    public String[] labelValues;
+
+    public PrometheusGauge() {
+
+    }
+
+    @Override
+    public void set(double delta,String ...labelValues) {
+        try {
+            List<String> mylist = new ArrayList<>(Arrays.asList(labelValues));
+            mylist.add(Prometheus.constLabels.get(Metrics.SERVICE));
+            String[] finalValue = mylist.toArray(new String[mylist.size()]);
+            this.myGauge.labels(finalValue).set(delta);
+        } catch (Throwable throwable) {
+            //log.warn(throwable.getMessage());
+        }
+    }
+
+    public PrometheusGauge(Gauge cb, String[] lns, String[] lvs) {
+        this.myGauge = cb;
+        this.labelNames = lns;
+        this.labelValues = lvs;
+    }
+
+    @Override
+    public XmGauge with(String... labelValue) {
+        /*String traceId = MDC.get("tid");
+        if (StringUtils.isEmpty(traceId)) {
+            traceId = "no traceId";
+        }*/
+        try {
+            if (this.labelNames.length != labelValue.length) {
+                log.warn("Incorrect numbers of labels : " + myGauge.describe().get(0).name);
+                return new PrometheusGauge();
+            }
+            return this;
+        } catch (Exception e) {
+            log.warn("prometheus gauge with error",e);
+            return null;
+        }
+    }
+
+    @Override
+    public void add(double delta,String... labelValue) {
+        this.add(Prometheus.constLabels.get(Metrics.SERVICE),delta,labelValue);
+    }
+
+    @Override
+    public void add(String service, double delta,String... labelValue) {
+
+        List<String> mylist = new ArrayList<>(Arrays.asList(labelValues));
+//        mylist.add(service);
+        String[] finalValue = mylist.toArray(new String[mylist.size()]);
+        try {
+            this.myGauge.labels(finalValue).inc(delta);
+        } catch (Exception e) {
+            log.warn("prometheus gauge add error",e);
+        }
+    }
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/PrometheusHistogram.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/PrometheusHistogram.java
@@ -1,0 +1,66 @@
+package com.xiaomi.youpin.prometheus.client;
+
+import io.prometheus.client.Histogram;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author zhangxiaowei
+ */
+@Slf4j
+public class PrometheusHistogram implements XmHistogram {
+
+    public Histogram myHistogram;
+    public String[] labelNames;
+    public String[] labelValues;
+
+    public PrometheusHistogram(Histogram cb, String[] lns, String[] lvs) {
+        this.myHistogram = cb;
+        this.labelNames = lns;
+        this.labelValues = lvs;
+    }
+
+    public PrometheusHistogram() {
+
+    }
+
+    @Override
+    public XmHistogram with(String... labelValues) {
+        /*String traceId = MDC.get("tid");
+        if (StringUtils.isEmpty(traceId)) {
+            traceId = "no traceId";
+        }*/
+        try {
+            if (this.labelNames.length != labelValues.length) {
+                log.warn("Incorrect numbers of labels : " + myHistogram.describe().get(0).name + " labelName: " + this.labelNames.length + " labelValues: " + this.labelValues.length);
+                return new PrometheusHistogram();
+            }
+            return this;
+        } catch (Exception e) {
+            log.warn("prometheus histogram with error",e);
+            return null;
+        }
+    }
+
+    @Override
+    public void observe(double delta,String... labelValue) {
+        this.observe(Prometheus.constLabels.get(Metrics.SERVICE), delta, labelValue);
+    }
+
+    @Override
+    public void observe(String service, double delta, String... labelValue) {
+        try {
+            List<String> mylist = new ArrayList<>(Arrays.asList(labelValue));
+//            mylist.add(service);
+            String[] finalValue = mylist.toArray(new String[mylist.size()]);
+            this.myHistogram.labels(finalValue).observe(delta);
+        } catch (Exception e) {
+            log.warn("prometheus histogram observe error",e);
+        }
+    }
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/XmCounter.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/XmCounter.java
@@ -1,0 +1,27 @@
+package com.xiaomi.youpin.prometheus.client;
+/**
+ * @author zhangxiaowei
+ */
+public interface XmCounter {
+     /**
+      * 填充label的value
+      *
+      * @param labelValues 标签值
+      * @return XMCounter
+      */
+     XmCounter with(String... labelValues);
+
+     /**
+      * Counter指标增加定量值
+      *
+      * @param delta 增加delta的数值
+      */
+     void add(double delta,String... labelValues);
+
+     /**
+      * Counter指标增加定量值
+      *
+      * @param delta 增加delta的数值
+      */
+     void add(String service, double delta,String... labelValues);
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/XmGauge.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/XmGauge.java
@@ -1,0 +1,36 @@
+package com.xiaomi.youpin.prometheus.client;
+/**
+ * @author zhangxiaowei
+ */
+public interface XmGauge {
+     /**
+      * 填充label的value
+      *
+      * @param labelValues 标签值
+      * @return XMGauge
+      */
+     XmGauge with(String... labelValues);
+
+     /**
+      * Gauge指标设置标量值
+      *
+      * @param delta 设置增量
+      */
+     void set(double delta,String... labelValue);
+
+     /**
+      * Gauge指标增加定量值
+      *
+      * @param delta 设置增量
+      */
+     void add(double delta,String... labelValue);
+
+     /**
+      * Gauge指标增加定量值
+      *
+      * @param delta 设置增量
+      */
+     void add(String service, double delta,String... labelValue);
+
+
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/XmHistogram.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/XmHistogram.java
@@ -1,0 +1,25 @@
+package com.xiaomi.youpin.prometheus.client;
+/**
+ * @author zhangxiaowei
+ */
+public interface XmHistogram {
+    /**
+     * 填充label的value值
+     *
+     * @param labelValues 标签值
+     * @return XmHistogram
+     */
+    XmHistogram with(String... labelValues);
+
+    /**
+     * 填入桶中的数据
+     * @param delta 设置增量
+     */
+    void observe(double delta,String... labelValue);
+
+    /**
+     * 填入桶中的数据
+     * @param delta 设置增量
+     */
+    void observe(String service, double delta,String... labelValue);
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/binder/ClassLoaderMetricsReduced.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/binder/ClassLoaderMetricsReduced.java
@@ -1,0 +1,38 @@
+package com.xiaomi.youpin.prometheus.client.binder;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.lang.NonNullApi;
+import io.micrometer.core.lang.NonNullFields;
+
+import java.lang.management.ClassLoadingMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.Collections;
+
+/**
+ * @Description
+ * @Author dingtao
+ * @Date 2021/10/27 3:59 下午
+ */
+@NonNullApi
+@NonNullFields
+public class ClassLoaderMetricsReduced implements MeterBinder {
+    private final Iterable<Tag> tags;
+
+    public ClassLoaderMetricsReduced() {
+        this(Collections.emptyList());
+    }
+
+    public ClassLoaderMetricsReduced(Iterable<Tag> tags) {
+        this.tags = tags;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        ClassLoadingMXBean classLoadingBean = ManagementFactory.getClassLoadingMXBean();
+        Gauge.builder("jvm.classes.loaded", classLoadingBean, ClassLoadingMXBean::getLoadedClassCount).tags(this.tags).description("The number of classes that are currently loaded in the Java virtual machine").baseUnit("classes").register(registry);
+    }
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/binder/JvmGcMetricsReduced.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/binder/JvmGcMetricsReduced.java
@@ -1,0 +1,191 @@
+package com.xiaomi.youpin.prometheus.client.binder;
+
+import com.sun.management.GarbageCollectionNotificationInfo;
+import com.sun.management.GcInfo;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.lang.NonNullApi;
+import io.micrometer.core.lang.NonNullFields;
+import io.micrometer.core.lang.Nullable;
+
+import javax.management.ListenerNotFoundException;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @Description
+ * @Author dingtao
+ * @Date 2021/10/27 4:04 下午
+ */
+@NonNullApi
+@NonNullFields
+public class JvmGcMetricsReduced implements MeterBinder, AutoCloseable{
+    private final boolean managementExtensionsPresent;
+    private final Iterable<Tag> tags;
+    @Nullable
+    private String youngGenPoolName;
+    @Nullable
+    private String oldGenPoolName;
+    private final List<Runnable> notificationListenerCleanUpRunnables;
+
+    public JvmGcMetricsReduced() {
+        this(Collections.emptyList());
+    }
+
+    public JvmGcMetricsReduced(Iterable<Tag> tags) {
+        this.managementExtensionsPresent = isManagementExtensionsPresent();
+        this.notificationListenerCleanUpRunnables = new CopyOnWriteArrayList();
+        Iterator var2 = ManagementFactory.getMemoryPoolMXBeans().iterator();
+
+        while(var2.hasNext()) {
+            MemoryPoolMXBean mbean = (MemoryPoolMXBean)var2.next();
+            String name = mbean.getName();
+            if (this.isYoungGenPool(name)) {
+                this.youngGenPoolName = name;
+            } else if (this.isOldGenPool(name)) {
+                this.oldGenPoolName = name;
+            }
+        }
+
+        this.tags = tags;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        Counter promotedBytes = Counter.builder("jvm.gc.memory.promoted").tags(this.tags).baseUnit("bytes").description("Count of positive increases in the size of the old generation memory pool before GC to after GC").register(registry);
+        Counter allocatedBytes = Counter.builder("jvm.gc.memory.allocated").tags(this.tags).baseUnit("bytes").description("Incremented for an increase in the size of the young generation memory pool after one GC to before the next").register(registry);
+        if (this.managementExtensionsPresent) {
+            AtomicLong youngGenSizeAfter = new AtomicLong(0L);
+            Iterator var7 = ManagementFactory.getGarbageCollectorMXBeans().iterator();
+
+            while(var7.hasNext()) {
+                GarbageCollectorMXBean mbean = (GarbageCollectorMXBean)var7.next();
+                if (mbean instanceof NotificationEmitter) {
+                    NotificationListener notificationListener = (notification, ref) -> {
+                        if (notification.getType().equals("com.sun.management.gc.notification")) {
+                            CompositeData cd = (CompositeData)notification.getUserData();
+                            GarbageCollectionNotificationInfo notificationInfo = GarbageCollectionNotificationInfo.from(cd);
+                            String gcCause = notificationInfo.getGcCause();
+                            String gcAction = notificationInfo.getGcAction();
+                            GcInfo gcInfo = notificationInfo.getGcInfo();
+                            long duration = gcInfo.getDuration();
+                            if (this.isConcurrentPhase(gcCause)) {
+                                Timer.builder("jvm.gc.concurrent.phase.time").tags(this.tags).tags(new String[]{"action", gcAction, "cause", gcCause}).description("Time spent in concurrent phase").register(registry).record(duration, TimeUnit.MILLISECONDS);
+                            } else {
+                                Timer.builder("jvm.gc.pause").tags(this.tags).tags(new String[]{"action", gcAction, "cause", gcCause}).description("Time spent in GC pause").register(registry).record(duration, TimeUnit.MILLISECONDS);
+                            }
+
+                            Map<String, MemoryUsage> before = gcInfo.getMemoryUsageBeforeGc();
+                            Map<String, MemoryUsage> after = gcInfo.getMemoryUsageAfterGc();
+                            long oldBefore;
+                            long oldAfter;
+                            long delta;
+                            if (this.oldGenPoolName != null) {
+                                oldBefore = ((MemoryUsage)before.get(this.oldGenPoolName)).getUsed();
+                                oldAfter = ((MemoryUsage)after.get(this.oldGenPoolName)).getUsed();
+                                delta = oldAfter - oldBefore;
+                                if (delta > 0L) {
+                                    promotedBytes.increment((double)delta);
+                                }
+
+                            }
+
+                            if (this.youngGenPoolName != null) {
+                                oldBefore = ((MemoryUsage)before.get(this.youngGenPoolName)).getUsed();
+                                oldAfter = ((MemoryUsage)after.get(this.youngGenPoolName)).getUsed();
+                                delta = oldBefore - youngGenSizeAfter.get();
+                                youngGenSizeAfter.set(oldAfter);
+                                if (delta > 0L) {
+                                    allocatedBytes.increment((double)delta);
+                                }
+                            }
+
+                        }
+                    };
+                    NotificationEmitter notificationEmitter = (NotificationEmitter)mbean;
+                    notificationEmitter.addNotificationListener(notificationListener, (NotificationFilter)null, (Object)null);
+                    this.notificationListenerCleanUpRunnables.add(() -> {
+                        try {
+                            notificationEmitter.removeNotificationListener(notificationListener);
+                        } catch (ListenerNotFoundException var3) {
+                        }
+
+                    });
+                }
+            }
+
+        }
+    }
+
+    private static boolean isManagementExtensionsPresent() {
+        try {
+            Class.forName("com.sun.management.GarbageCollectionNotificationInfo", false, JvmGcMetricsReduced.class.getClassLoader());
+            return true;
+        } catch (Throwable var1) {
+            return false;
+        }
+    }
+
+    private boolean isConcurrentPhase(String cause) {
+        return "No GC".equals(cause);
+    }
+
+    private boolean isOldGenPool(String name) {
+        return name.endsWith("Old Gen") || name.endsWith("Tenured Gen");
+    }
+
+    private boolean isYoungGenPool(String name) {
+        return name.endsWith("Eden Space");
+    }
+
+    @Override
+    public void close() {
+        this.notificationListenerCleanUpRunnables.forEach(Runnable::run);
+    }
+
+    @NonNullApi
+    static enum GcGenerationAge {
+        OLD,
+        YOUNG,
+        UNKNOWN;
+
+        private static Map<String, GcGenerationAge> knownCollectors = new HashMap<String, GcGenerationAge>() {
+            {
+                this.put("ConcurrentMarkSweep", GcGenerationAge.OLD);
+                this.put("Copy", GcGenerationAge.YOUNG);
+                this.put("G1 Old Generation", GcGenerationAge.OLD);
+                this.put("G1 Young Generation", GcGenerationAge.YOUNG);
+                this.put("MarkSweepCompact", GcGenerationAge.OLD);
+                this.put("PS MarkSweep", GcGenerationAge.OLD);
+                this.put("PS Scavenge", GcGenerationAge.YOUNG);
+                this.put("ParNew", GcGenerationAge.YOUNG);
+            }
+        };
+
+        private GcGenerationAge() {
+        }
+
+        static GcGenerationAge fromName(String name) {
+            return (GcGenerationAge)knownCollectors.getOrDefault(name, UNKNOWN);
+        }
+    }
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/binder/JvmMemoryMetricsReduced.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/binder/JvmMemoryMetricsReduced.java
@@ -1,0 +1,82 @@
+package com.xiaomi.youpin.prometheus.client.binder;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.lang.NonNullApi;
+import io.micrometer.core.lang.NonNullFields;
+import io.micrometer.core.lang.Nullable;
+
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.function.ToLongFunction;
+
+/**
+ * @Description
+ * @Author dingtao
+ * @Date 2021/10/27 4:15 下午
+ */
+@NonNullApi
+@NonNullFields
+public class JvmMemoryMetricsReduced implements MeterBinder {
+    private final Iterable<Tag> tags;
+
+    public JvmMemoryMetricsReduced() {
+        this(Collections.emptyList());
+    }
+
+    public JvmMemoryMetricsReduced(Iterable<Tag> tags) {
+        this.tags = tags;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        Iterator var2 = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class).iterator();
+
+        while(var2.hasNext()) {
+            BufferPoolMXBean bufferPoolBean = (BufferPoolMXBean)var2.next();
+            Iterable<Tag> tagsWithId = Tags.concat(this.tags, new String[]{"id", bufferPoolBean.getName()});
+            Gauge.builder("jvm.buffer.memory.used", bufferPoolBean, BufferPoolMXBean::getMemoryUsed).tags(tagsWithId).description("An estimate of the memory that the Java virtual machine is using for this buffer pool").baseUnit("bytes").register(registry);
+            Gauge.builder("jvm.buffer.total.capacity", bufferPoolBean, BufferPoolMXBean::getTotalCapacity).tags(tagsWithId).description("An estimate of the total capacity of the buffers in this pool").baseUnit("bytes").register(registry);
+        }
+
+        var2 = ManagementFactory.getPlatformMXBeans(MemoryPoolMXBean.class).iterator();
+
+        while(var2.hasNext()) {
+            MemoryPoolMXBean memoryPoolBean = (MemoryPoolMXBean)var2.next();
+            String area = MemoryType.HEAP.equals(memoryPoolBean.getType()) ? "heap" : "nonheap";
+            Iterable<Tag> tagsWithId = Tags.concat(this.tags, new String[]{"id", memoryPoolBean.getName(), "area", area});
+            Gauge.builder("jvm.memory.used", memoryPoolBean, (mem) -> {
+                return this.getUsageValue(mem, MemoryUsage::getUsed);
+            }).tags(tagsWithId).description("The amount of used memory").baseUnit("bytes").register(registry);
+            Gauge.builder("jvm.memory.committed", memoryPoolBean, (mem) -> {
+                return this.getUsageValue(mem, MemoryUsage::getCommitted);
+            }).tags(tagsWithId).description("The amount of memory in bytes that is committed for the Java virtual machine to use").baseUnit("bytes").register(registry);
+            Gauge.builder("jvm.memory.max", memoryPoolBean, (mem) -> {
+                return this.getUsageValue(mem, MemoryUsage::getMax);
+            }).tags(tagsWithId).description("The maximum amount of memory in bytes that can be used for memory management").baseUnit("bytes").register(registry);
+        }
+
+    }
+
+    private double getUsageValue(MemoryPoolMXBean memoryPoolMXBean, ToLongFunction<MemoryUsage> getter) {
+        MemoryUsage usage = this.getUsage(memoryPoolMXBean);
+        return usage == null ? 0.0D / 0.0 : (double)getter.applyAsLong(usage);
+    }
+
+    @Nullable
+    private MemoryUsage getUsage(MemoryPoolMXBean memoryPoolMXBean) {
+        try {
+            return memoryPoolMXBean.getUsage();
+        } catch (InternalError var3) {
+            return null;
+        }
+    }
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/binder/JvmThreadMetricsReduced.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/binder/JvmThreadMetricsReduced.java
@@ -1,0 +1,35 @@
+package com.xiaomi.youpin.prometheus.client.binder;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.lang.NonNullApi;
+import io.micrometer.core.lang.NonNullFields;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.Collections;
+
+/**
+ * @Description
+ * @Author dingtao
+ * @Date 2021/10/27 10:49 上午
+ */
+@NonNullApi
+@NonNullFields
+public class JvmThreadMetricsReduced implements MeterBinder {
+
+    private final Iterable<Tag> tags;
+
+    public JvmThreadMetricsReduced() {
+        this.tags = Collections.emptyList();
+    }
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+        Gauge.builder("jvm.threads.peak", threadBean, ThreadMXBean::getPeakThreadCount).tags(this.tags).description("The peak live thread count since the Java virtual machine started or peak was reset").baseUnit("threads").register(registry);
+        Gauge.builder("jvm.threads.daemon", threadBean, ThreadMXBean::getDaemonThreadCount).tags(this.tags).description("The current number of live daemon threads").baseUnit("threads").register(registry);
+        Gauge.builder("jvm.threads.live", threadBean, ThreadMXBean::getThreadCount).tags(this.tags).description("The current number of live threads including both daemon and non-daemon threads").baseUnit("threads").register(registry);
+    }
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/multi/MutiMetrics.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/multi/MutiMetrics.java
@@ -1,0 +1,66 @@
+package com.xiaomi.youpin.prometheus.client.multi;
+
+import com.xiaomi.youpin.prometheus.client.XmCounter;
+import com.xiaomi.youpin.prometheus.client.XmGauge;
+import com.xiaomi.youpin.prometheus.client.XmHistogram;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+
+/**
+ * @author zhangxiaowei
+ */
+@Slf4j
+public class MutiMetrics {
+
+    public MutiPrometheus gMetricsMgr;
+    /**
+     * group+service形成namespace标识
+     */
+    public static final String GROUP = "group";
+    public static final String SERVICE = "service";
+    public static final String APPLICATION = "application";
+
+    public void init(String group,String service) {
+        setGroup(group);
+        setService(service);
+    }
+
+
+    public void setGroup(String group) {
+        this.gMetricsMgr.constLabels.put(GROUP, group);
+    }
+
+    public void setService(String service) {
+        this.gMetricsMgr.constLabels.put(SERVICE, service);
+    }
+
+    public static double[] DEFAULT_LATENCY_BUCKETS =
+            new double[]{.01, .05, 1, 5, 7.5, 10, 25, 50, 100, 200, 500, 1000,1500,2000,3000,4000,5000};
+
+    public MutiMetrics() {
+        gMetricsMgr = new MutiPrometheus();
+        gMetricsMgr.constLabels = new HashMap<>();
+    }
+
+    public XmCounter newCounter(String metricName, String... labelNames) {
+        try {
+            return gMetricsMgr.newCounter(metricName, labelNames);
+        } catch (Throwable throwable) {
+            log.warn(throwable.getMessage());
+            return null;
+        }
+    }
+
+    public XmGauge newGauge(String metricName, String... labelNames) {
+        return gMetricsMgr.newGauge(metricName, labelNames);
+    }
+
+    public XmHistogram newHistogram(String metricName, double[] buckets, String... labelNames) {
+        if (buckets != null && buckets.length > 0) {
+            return gMetricsMgr.newHistogram(metricName, buckets, labelNames);
+        }
+        return gMetricsMgr.newHistogram(metricName, DEFAULT_LATENCY_BUCKETS, labelNames);
+    }
+
+}

--- a/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/multi/MutiPrometheus.java
+++ b/jcommon/prometheus/prometheus-trace-etl/src/main/java/com/xiaomi/youpin/prometheus/client/multi/MutiPrometheus.java
@@ -1,0 +1,173 @@
+package com.xiaomi.youpin.prometheus.client.multi;
+
+import com.xiaomi.youpin.prometheus.client.Metrics;
+import com.xiaomi.youpin.prometheus.client.MetricsManager;
+import com.xiaomi.youpin.prometheus.client.PrometheusCounter;
+import com.xiaomi.youpin.prometheus.client.PrometheusGauge;
+import com.xiaomi.youpin.prometheus.client.PrometheusHistogram;
+import com.xiaomi.youpin.prometheus.client.XmCounter;
+import com.xiaomi.youpin.prometheus.client.XmGauge;
+import com.xiaomi.youpin.prometheus.client.XmHistogram;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author zhangxiaowei
+ */
+@Slf4j
+public class MutiPrometheus implements MetricsManager {
+
+   public static final int CONST_LABELS_NUM = 2;
+   public Map<String, String> constLabels;
+   public Map<String, Object> prometheusMetrics;
+   public Map<String,Object> prometheusTypeMetrics;
+
+   private byte[] lock = new byte[0];
+   private byte[] typeLock = new byte[0];
+
+   public MutiPrometheus() {
+      this.prometheusMetrics = new ConcurrentHashMap<>();
+      this.prometheusTypeMetrics = new ConcurrentHashMap<>();
+   }
+
+   @Override
+   public XmCounter newCounter(String metricName, String... labelName) {
+      if (prometheusTypeMetrics.containsKey(metricName)) {
+         return (XmCounter) prometheusTypeMetrics.get(metricName);
+      }
+      synchronized (typeLock) {
+         PrometheusCounter prometheusCounter = new PrometheusCounter(getCounter(metricName, labelName), labelName, null);
+         prometheusTypeMetrics.put(metricName,prometheusCounter);
+         return prometheusCounter;
+      }
+   }
+
+   @Override
+   public XmGauge newGauge(String metricName, String... labelName) {
+      if (prometheusTypeMetrics.containsKey(metricName)) {
+         return (XmGauge) prometheusTypeMetrics.get(metricName);
+      }
+      synchronized (typeLock) {
+         PrometheusGauge prometheusGauge = new PrometheusGauge(getGauge(metricName, labelName), labelName, null);
+         prometheusTypeMetrics.put(metricName,prometheusGauge);
+         return prometheusGauge;
+      }
+
+   }
+
+   @Override
+   public XmHistogram newHistogram(String metricName, double[] bucket, String... labelNames) {
+      if (prometheusTypeMetrics.containsKey(metricName)) {
+         return (XmHistogram) prometheusTypeMetrics.get(metricName);
+      }
+      synchronized (typeLock) {
+         PrometheusHistogram prometheusHistogram = new PrometheusHistogram(getHistogram(metricName, bucket, labelNames), labelNames, null);
+         prometheusTypeMetrics.put(metricName,prometheusHistogram);
+         return prometheusHistogram;
+      }
+   }
+
+   public Counter getCounter(String metricName, String... labelName) {
+      if (constLabels.size() != MutiPrometheus.CONST_LABELS_NUM) {
+         return null;
+      }
+      try {
+         //如果有直接返回
+         if (prometheusMetrics.containsKey(metricName)) {
+            //log.debug("already have metric:" + metricName);
+            return (Counter) prometheusMetrics.get(metricName);
+         }
+
+         synchronized (lock) {
+            //没有需要先注册一个
+            List<String> mylist = new ArrayList<>(Arrays.asList(labelName));
+//            mylist.add(Metrics.APPLICATION);
+            String[] finalValue = mylist.toArray(new String[mylist.size()]);
+            Counter newCounter = Counter.build()
+                    .name(metricName)
+                    .namespace(constLabels.get(Metrics.GROUP) + "_" + constLabels.get(Metrics.SERVICE))
+                    .labelNames(finalValue)
+                    .help(metricName)
+                    .register();
+
+            prometheusMetrics.put(metricName, newCounter);
+            return newCounter;
+         }
+      } catch (Throwable throwable) {
+         log.warn(throwable.getMessage());
+         return null;
+      }
+   }
+
+   public Gauge getGauge(String metricName, String... labelName) {
+      if (constLabels.size() != MutiPrometheus.CONST_LABELS_NUM) {
+         return null;
+      }
+      try {
+         //如果有直接返回
+         if (prometheusMetrics.containsKey(metricName)) {
+           // log.debug("already have metric:" + metricName);
+            return (Gauge) prometheusMetrics.get(metricName);
+         }
+         synchronized (lock) {
+            //没有需要先注册一个
+            List<String> mylist = new ArrayList<>(Arrays.asList(labelName));
+//            mylist.add(Metrics.APPLICATION);
+            String[] finalValue = mylist.toArray(new String[mylist.size()]);
+            Gauge newGauge = Gauge.build()
+                    .name(metricName)
+                    .namespace(constLabels.get(Metrics.GROUP) + "_" + constLabels.get(Metrics.SERVICE))
+                    .labelNames(finalValue)
+                    .help(metricName)
+                    .register();
+
+            prometheusMetrics.put(metricName, newGauge);
+            return newGauge;
+         }
+      } catch (Throwable throwable) {
+         log.warn(throwable.getMessage());
+         return null;
+      }
+
+   }
+
+   public Histogram getHistogram(String metricName, double[] buckets, String... labelNames) {
+      if (constLabels.size() != MutiPrometheus.CONST_LABELS_NUM) {
+         return null;
+      }
+      try {
+         //如果有直接返回
+         if (prometheusMetrics.containsKey(metricName)) {
+           // log.debug("already have metric:" + metricName);
+            return (Histogram) prometheusMetrics.get(metricName);
+         }
+
+         synchronized (lock) {
+            //没有需要注册一个
+            List<String> mylist = new ArrayList<>(Arrays.asList(labelNames));
+//            mylist.add(Metrics.APPLICATION);
+            String[] finalValue = mylist.toArray(new String[mylist.size()]);
+            Histogram newHistogram = Histogram.build()
+                    .buckets(buckets)
+                    .name(metricName)
+                    .namespace(constLabels.get(Metrics.GROUP) + "_" + constLabels.get(Metrics.SERVICE))
+                    .labelNames(finalValue)
+                    .help(metricName)
+                    .register();
+            prometheusMetrics.put(metricName, newHistogram);
+            return newHistogram;
+         }
+      } catch (Throwable throwable) {
+         log.warn(throwable.getMessage());
+         return null;
+      }
+   }
+}


### PR DESCRIPTION
The "promethe-trace-etl" module provides the ability to create multiple Metrics instances and customize thread monitoring