### PR TITLE
[enhancement] JCommon MongoDB fix default role for annotation

### DIFF
--- a/jcommon/docean-plugin/docean-plugin-mongodb/src/main/java/run/mone/auth/Auth.java
+++ b/jcommon/docean-plugin/docean-plugin-mongodb/src/main/java/run/mone/auth/Auth.java
@@ -29,5 +29,5 @@ public @interface Auth {
 
     String name() default "name";
 
-    String role() default "admin";
+    String role() default "user";
 }


### PR DESCRIPTION
JCommon MongoDB fix default role for annotation