### PR TITLE
refactor(es): 移除 EsClient 中的参数验证

### DIFF
--- a/jcommon/es/pom.xml
+++ b/jcommon/es/pom.xml
@@ -9,7 +9,7 @@
         <version>1.6.1-jdk21</version>
     </parent>
     <artifactId>es</artifactId>
-    <version>1.6.2-jdk21</version>
+    <version>1.6.3-jdk21</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jcommon/es/src/main/java/com/xiaomi/mone/es/EsClient.java
+++ b/jcommon/es/src/main/java/com/xiaomi/mone/es/EsClient.java
@@ -56,7 +56,6 @@ import java.util.concurrent.TimeUnit;
  * @author goodjava@qq.com
  */
 public class EsClient {
-
     private static Sniffer sniffer;
     private static final int SNIFF_INTERVAL_MILLIS = 60 * 1000 * 3;
     private static final int SNIFF_AFTER_FAILURE_DELAY_MILLIS = 60 * 1000;
@@ -132,7 +131,7 @@ public class EsClient {
 
 
     public EsClient(String esAddr, String user, String pwd) {
-        validateParams(esAddr, user, pwd);
+//        validateParams(esAddr, user, pwd);
 
         List<HttpHost> hosts = createHttpHosts(esAddr);
 


### PR DESCRIPTION
- 删除了 EsClient 构造函数中的 validateParams 方法调用 -该方法似乎未在代码中定义，移除以修复潜在错误- 更新了项目版本号至1.6.3-jdk21