### PR TITLE
feat(mcp-feishu): add lark document mcp util

### DIFF
--- a/jcommon/mcp/mcp-feishu/pom.xml
+++ b/jcommon/mcp/mcp-feishu/pom.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>run.mone</groupId>
+        <artifactId>mcp</artifactId>
+        <version>1.6.1-jdk21-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mcp-feishu</artifactId>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <mockito.version>5.3.1</mockito.version>
+        <junit-jupiter.version>5.11.4</junit-jupiter.version>
+    </properties>
+
+    <dependencies>
+        <!-- 飞书 SDK -->
+        <dependency>
+            <groupId>com.larksuite.oapi</groupId>
+            <artifactId>oapi-sdk</artifactId>
+            <version>2.0.27</version>
+        </dependency>
+
+        <!-- Spring Boot Starter -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <version>3.4.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>6.2.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>6.2.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>6.2.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>6.2.1</version>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>3.4.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+
+        <plugins>
+
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.7.14</version>
+                <configuration>
+                    <mainClass>run.mone.mcp.feishu.FeishuApplication</mainClass>
+                    <finalName>app</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+        </plugins>
+
+    </build>
+
+</project> 

--- a/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/FeishuApplication.java
+++ b/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/FeishuApplication.java
@@ -1,0 +1,13 @@
+package run.mone.mcp.feishu;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan({"run.mone.mcp.feishu"})
+public class FeishuApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(FeishuApplication.class, args);
+    }
+} 

--- a/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/config/McpStdioTransportConfig.java
+++ b/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/config/McpStdioTransportConfig.java
@@ -1,0 +1,22 @@
+package run.mone.mcp.feishu.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import run.mone.hive.mcp.server.transport.StdioServerTransport;
+
+@Configuration
+@ConditionalOnProperty(name = "stdio.enabled", havingValue = "true")
+class McpStdioTransportConfig {
+    /**
+     * stdio 通信
+     * @param mapper
+     * @return
+     */
+    @Bean
+    StdioServerTransport stdioServerTransport(ObjectMapper mapper) {
+        return new StdioServerTransport(mapper);
+    }
+
+}

--- a/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/function/FeishuDocFunction.java
+++ b/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/function/FeishuDocFunction.java
@@ -1,0 +1,123 @@
+package run.mone.mcp.feishu.function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import run.mone.hive.mcp.spec.McpSchema;
+import run.mone.mcp.feishu.model.DocBlock;
+import run.mone.mcp.feishu.model.DocContent;
+import run.mone.mcp.feishu.model.DocPermission;
+import run.mone.mcp.feishu.model.Files;
+import run.mone.mcp.feishu.service.FeishuDocService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+@Data
+@Slf4j
+@Component
+public class FeishuDocFunction implements Function<Map<String, Object>, McpSchema.CallToolResult> {
+
+    private String name = "feishuDoc";
+
+    private String desc = "Feishu document operations including creating and managing documents";
+
+    private String toolScheme = """
+            {
+                "type": "object",
+                "properties": {
+                    "operation": {
+                        "type": "string",
+                        "enum": ["createDocument", "addBlock", "getFileInfo", "getDocument", "getRootFolder"],
+                        "description": "Operation type for Feishu document. Supported operations:\\n1. createDocument: Create new document, requires title parameter. Example: {'operation': 'createDocument', 'title': 'New Document'}\\n2. addBlock: Add content blocks, requires block parameter with docId and elements. Example: {'operation': 'addBlock', 'block': {'docId': 'docx8H1i9Ko0TPLt', 'elements': {'2': 'content', '3': 'heading'}}}\\n3. getFileInfo: Get document info, requires documentId. Example: {'operation': 'getFileInfo', 'documentId': 'docx8H1i9Ko0TPLt'}\\n4. getDocument: Get document content, requires documentId. Example: {'operation': 'getDocument', 'documentId': 'docx8H1i9Ko0TPLt'}\\n5. getRootFolder: Get root folder token. Example: {'operation': 'getRootFolder'}"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Document title for createDocument operation. Example: 'Project Document', 'Meeting Notes'"
+                    },
+                    "folderToken": {
+                        "type": "string",
+                        "description": "Parent folder token for document creation. If not provided, document will be created in root folder. Example: 'fldcnxxxxxxxx'"
+                    },
+                    "documentId": {
+                        "type": "string",
+                        "description": "Document ID for getFileInfo and getDocument operations. Example: 'docx8H1i9Ko0TPLt'"
+                    },
+                    "block": {
+                        "type": "object",
+                        "description": "Document block structure for addBlock operation. Block types: 1=Page, 2=Text, 3=Heading1, 4=Heading2, 5=Heading3, 6=Heading4, 7=Heading5, 8=Heading6, 9=Heading7, 10=Heading8, 11=Heading9, 12=Bullet List, 13=Ordered List, 14=Code Block, 15=Quote. Example: {'docId': 'docx8H1i9Ko0TPLt', 'elements': {'3': 'Document Title', '2': 'Content', '12': 'List Item', '14': 'Code Example'}}"
+                    }
+                },
+                "required": ["operation"]
+            }
+            """;
+
+    private final FeishuDocService docService;
+    private final ObjectMapper objectMapper;
+
+    public FeishuDocFunction(FeishuDocService docService, ObjectMapper objectMapper) {
+        this.docService = docService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public McpSchema.CallToolResult apply(Map<String, Object> args) {
+        String operation = (String) args.get("operation");
+        log.info("Executing Feishu document operation: {}", operation);
+
+        try {
+            String result = switch (operation) {
+                case "createDocument" -> createDocument(args);
+                case "addBlock" -> addBlock(args);
+                case "getFileInfo" -> getFileInfo(args);
+                case "getDocument" -> getDocument(args);
+                case "getRootFolder" -> getRootFolder();
+                default -> throw new IllegalArgumentException("Unknown operation: " + operation);
+            };
+
+            return new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(result)), false);
+        } catch (Exception e) {
+            log.error("Failed to execute Feishu document operation: {}", e.getMessage());
+            return new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("Error: " + e.getMessage())), true);
+        }
+    }
+
+    private String createDocument(Map<String, Object> args) throws Exception {
+        String title = (String) args.get("title");
+        String folderToken = (String) args.get("folderToken");
+
+        DocContent doc = docService.createDocument(title, folderToken);
+        return objectMapper.writeValueAsString(doc);
+    }
+
+    private String addBlock(Map<String, Object> args) throws Exception {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> blockData = (Map<String, Object>) args.get("block");
+        DocBlock block = objectMapper.convertValue(blockData, DocBlock.class);
+
+        DocBlock createdBlock = docService.createDocumentBlock(block);
+        return objectMapper.writeValueAsString(createdBlock);
+    }
+
+    private String getFileInfo(Map<String, Object> args) throws Exception {
+        String documentId = (String) args.get("documentId");
+
+        Files fileInfo = docService.getFileInfo(documentId);
+        return objectMapper.writeValueAsString(fileInfo);
+    }
+
+    private String getDocument(Map<String, Object> args) throws Exception {
+        String documentId = (String) args.get("documentId");
+
+        DocContent doc = docService.getDocument(documentId);
+        return objectMapper.writeValueAsString(doc);
+    }
+
+    private String getRootFolder() throws Exception {
+        String rootFolderToken = docService.getRootFolderToken();
+        return objectMapper.writeValueAsString(Map.of("rootFolderToken", rootFolderToken));
+    }
+
+} 

--- a/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/model/BlockType.java
+++ b/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/model/BlockType.java
@@ -1,0 +1,77 @@
+package run.mone.mcp.feishu.model;
+
+public enum BlockType {
+    PAGE(1, "页面 Block"),
+    TEXT(2, "文本 Block"),
+    HEADING_1(3, "标题 1 Block"),
+    HEADING_2(4, "标题 2 Block"),
+    HEADING_3(5, "标题 3 Block"),
+    HEADING_4(6, "标题 4 Block"),
+    HEADING_5(7, "标题 5 Block"),
+    HEADING_6(8, "标题 6 Block"),
+    HEADING_7(9, "标题 7 Block"),
+    HEADING_8(10, "标题 8 Block"),
+    HEADING_9(11, "标题 9 Block"),
+    BULLET_LIST(12, "无序列表 Block"),
+    ORDERED_LIST(13, "有序列表 Block"),
+    CODE(14, "代码块 Block"),
+    QUOTE(15, "引用 Block"),
+    TODO(17, "待办事项 Block"),
+    BITABLE(18, "多维表格 Block"),
+    CALLOUT(19, "高亮块 Block"),
+    CHAT_CARD(20, "会话卡片 Block"),
+    DIAGRAM(21, "流程图 & UML Block"),
+    DIVIDER(22, "分割线 Block"),
+    FILE(23, "文件 Block"),
+    GRID(24, "分栏 Block"),
+    GRID_COLUMN(25, "分栏列 Block"),
+    IFRAME(26, "内嵌网页 Block"),
+    IMAGE(27, "图片 Block"),
+    WIDGET(28, "开放平台小组件 Block"),
+    MINDNOTE(29, "思维笔记 Block"),
+    SHEET(30, "电子表格 Block"),
+    TABLE(31, "表格 Block"),
+    TABLE_CELL(32, "表格单元格 Block"),
+    VIEW(33, "视图 Block"),
+    QUOTE_CONTAINER(34, "引用容器 Block"),
+    TASK(35, "任务 Block"),
+    OKR(36, "OKR Block"),
+    OKR_OBJECTIVE(37, "OKR Objective Block"),
+    OKR_KEY_RESULT(38, "OKR Key Result Block"),
+    OKR_PROGRESS(39, "OKR 进展 Block"),
+    DOC_WIDGET(40, "文档小组件 Block"),
+    JIRA_ISSUE(41, "Jira 问题 Block"),
+    WIKI_CATALOG(42, "Wiki 子目录 Block"),
+    BOARD(43, "画板 Block"),
+    AGENDA(44, "议程 Block"),
+    AGENDA_ITEM(45, "议程项 Block"),
+    AGENDA_ITEM_TITLE(46, "议程项标题 Block"),
+    AGENDA_ITEM_CONTENT(47, "议程项内容 Block"),
+    LINK_PREVIEW(48, "链接预览 Block"),
+    UNSUPPORTED(999, "未支持 Block");
+
+    private final int value;
+    private final String description;
+
+    BlockType(int value, String description) {
+        this.value = value;
+        this.description = description;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static BlockType fromValue(int value) {
+        for (BlockType type : values()) {
+            if (type.value == value) {
+                return type;
+            }
+        }
+        return UNSUPPORTED;
+    }
+} 

--- a/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/model/DocBlock.java
+++ b/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/model/DocBlock.java
@@ -1,0 +1,96 @@
+package run.mone.mcp.feishu.model;
+
+import com.lark.oapi.service.docx.v1.model.Block;
+import com.lark.oapi.service.docx.v1.model.Text;
+import com.lark.oapi.service.docx.v1.model.TextElement;
+import com.lark.oapi.service.docx.v1.model.TextRun;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Accessors(chain = true)
+public class DocBlock {
+    private String blockId;
+    private String docId;
+    private String parentId;
+    private Map<Integer, String> elements;
+
+    public Block[] toFeishuBlocks() {
+        if (parentId == null || parentId.isEmpty()) {
+            throw new IllegalStateException("Parent block ID is required");
+        }
+
+        List<Block> blocks = new ArrayList<>();
+        
+        elements.forEach((type, content) -> {
+            Block.Builder blockBuilder = Block.newBuilder()
+                    .parentId(this.parentId)
+                    .blockType(type);
+
+            // 创建文本内容
+            Text text = new Text();
+            TextElement textElement = new TextElement();
+            TextRun textRun = new TextRun();
+            textRun.setContent(content);
+            textElement.setTextRun(textRun);
+            text.setElements(new TextElement[]{textElement});
+
+            // 根据type设置对应的字段
+            switch (type) {
+                case 1: // 页面 Block
+                    blockBuilder.page(text);
+                    break;
+                case 2: // 文本 Block
+                    blockBuilder.text(text);
+                    break;
+                case 3: // 标题 1 Block
+                    blockBuilder.heading1(text);
+                    break;
+                case 4: // 标题 2 Block
+                    blockBuilder.heading2(text);
+                    break;
+                case 5: // 标题 3 Block
+                    blockBuilder.heading3(text);
+                    break;
+                case 6: // 标题 4 Block
+                    blockBuilder.heading4(text);
+                    break;
+                case 7: // 标题 5 Block
+                    blockBuilder.heading5(text);
+                    break;
+                case 8: // 标题 6 Block
+                    blockBuilder.heading6(text);
+                    break;
+                case 9: // 标题 7 Block
+                    blockBuilder.heading7(text);
+                    break;
+                case 10: // 标题 8 Block
+                    blockBuilder.heading8(text);
+                    break;
+                case 11: // 标题 9 Block
+                    blockBuilder.heading9(text);
+                    break;
+                case 12: // 无序列表 Block
+                    blockBuilder.bullet(text);
+                    break;
+                case 13: // 有序列表 Block
+                    blockBuilder.ordered(text);
+                    break;
+                case 14: // 代码块 Block
+                    blockBuilder.code(text);
+                    break;
+                case 15: // 引用 Block
+                    blockBuilder.quote(text);
+                    break;
+            }
+
+            blocks.add(blockBuilder.build());
+        });
+
+        return blocks.toArray(new Block[0]);
+    }
+} 

--- a/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/model/DocContent.java
+++ b/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/model/DocContent.java
@@ -1,0 +1,20 @@
+package run.mone.mcp.feishu.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+@Data
+@Accessors(chain = true)
+public class DocContent {
+    private String documentId;
+    private String title;
+    private String folderToken;
+    private List<DocBlock> blocks;
+    private Long createTime;
+    private Long updateTime;
+    private String creator;
+    private String owner;
+    private String url;  // 文档访问链接
+} 

--- a/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/model/DocPermission.java
+++ b/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/model/DocPermission.java
@@ -1,0 +1,13 @@
+package run.mone.mcp.feishu.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class DocPermission {
+    private String documentId;
+    private String userId;
+    private String userType; // user, group, department
+    private String perm; // view, edit, full_access
+} 

--- a/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/model/Files.java
+++ b/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/model/Files.java
@@ -1,0 +1,26 @@
+package run.mone.mcp.feishu.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author caobaoyu
+ * @description:
+ * @date 2025-02-13 15:02
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Files{
+
+    private String name;
+
+    private String url;
+
+    private String type;
+
+    private String token;
+}

--- a/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/server/FeishuMcpServer.java
+++ b/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/server/FeishuMcpServer.java
@@ -1,0 +1,72 @@
+package run.mone.mcp.feishu.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import run.mone.hive.mcp.server.McpServer;
+import run.mone.hive.mcp.server.McpServer.ToolRegistration;
+import run.mone.hive.mcp.server.McpSyncServer;
+import run.mone.hive.mcp.spec.McpSchema.ServerCapabilities;
+import run.mone.hive.mcp.spec.McpSchema.Tool;
+import run.mone.hive.mcp.spec.ServerMcpTransport;
+import run.mone.mcp.feishu.function.FeishuDocFunction;
+import run.mone.mcp.feishu.service.FeishuDocService;
+
+@Slf4j
+@Component
+public class FeishuMcpServer {
+
+    private final ServerMcpTransport transport;
+    private final FeishuDocService docService;
+    private final ObjectMapper objectMapper;
+    private McpSyncServer syncServer;
+
+    public FeishuMcpServer(ServerMcpTransport transport, FeishuDocService docService, ObjectMapper objectMapper) {
+        this.transport = transport;
+        this.docService = docService;
+        this.objectMapper = objectMapper;
+        log.info("FeishuMcpServer initialized with transport: {}", transport);
+    }
+
+    public McpSyncServer start() {
+        log.info("Starting FeishuMcpServer...");
+        McpSyncServer syncServer = McpServer.using(transport)
+                .serverInfo("lark_doc_mcp", "1.0.0")
+                .capabilities(ServerCapabilities.builder()
+                        .tools(true)
+                        .logging()
+                        .build())
+                .sync();
+
+        // 注册飞书文档工具
+        log.info("Registering feishu doc tool...");
+        try {
+            FeishuDocFunction function = new FeishuDocFunction(docService, objectMapper);
+            var toolRegistration = new ToolRegistration(
+                    new Tool(function.getName(), function.getDesc(), function.getToolScheme()), function
+            );
+            syncServer.addTool(toolRegistration);
+            log.info("Successfully registered feishu doc tool");
+        } catch (Exception e) {
+            log.error("Failed to register feishu doc tool", e);
+            throw e;
+        }
+
+        return syncServer;
+    }
+
+    @PostConstruct
+    public void init() {
+        this.syncServer = start();
+    }
+
+    @PreDestroy
+    public void stop() {
+        if (this.syncServer != null) {
+            log.info("Stopping FeishuMcpServer...");
+            this.syncServer.closeGracefully();
+        }
+    }
+} 

--- a/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/service/FeishuDocService.java
+++ b/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/service/FeishuDocService.java
@@ -1,0 +1,160 @@
+package run.mone.mcp.feishu.service;
+
+import com.lark.oapi.core.Config;
+import com.lark.oapi.service.docx.v1.DocxService;
+import com.lark.oapi.service.docx.v1.model.*;
+import com.lark.oapi.service.drive.v1.DriveService;
+import com.lark.oapi.service.drive.v1.model.ListFileReq;
+import com.lark.oapi.service.drive.v1.model.ListFileResp;
+import com.lark.oapi.service.drive.v1.model.PatchPermissionPublicReq;
+import com.lark.oapi.service.drive.v1.model.PermissionPublicRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import run.mone.mcp.feishu.model.DocBlock;
+import run.mone.mcp.feishu.model.DocContent;
+import run.mone.mcp.feishu.model.Files;
+import run.mone.mcp.feishu.util.FeishuHttpClient;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class FeishuDocService {
+
+    private final DocxService docxService;
+    private final DriveService driveService;
+    private final FeishuHttpClient httpClient;
+
+    public FeishuDocService() {
+        String appId = System.getenv("LARK_APP_ID");
+        String appSecret = System.getenv("LARK_APP_SECRET");
+
+        if (appId == null || appSecret == null) {
+            throw new IllegalStateException("FEISHU_APP_ID and FEISHU_APP_SECRET system properties must be set");
+        }
+
+        Config config = new Config();
+        config.setAppId(appId);
+        config.setAppSecret(appSecret);
+        this.docxService = new DocxService(config);
+        this.driveService = new DriveService(config);
+        this.httpClient = new FeishuHttpClient(appId, appSecret);
+    }
+
+    public String getRootFolderToken() throws Exception {
+        Map<String, Object> response = httpClient.get("/drive/explorer/v2/root_folder/meta", null);
+        Map<String, Object> data = (Map<String, Object>) response.get("data");
+        return (String) data.get("token");
+    }
+
+    public List<Files> getDocumentFiles() throws Exception {
+        ListFileReq req = ListFileReq.newBuilder()
+                .orderBy("EditedTime")
+                .pageSize(10)
+                .direction("DESC")
+                .build();
+
+        // 发起请求
+        ListFileResp resp = driveService.file().list(req);
+        return Arrays.stream(resp.getData().getFiles()).map(i -> Files.builder()
+                        .url(i.getUrl())
+                        .type(i.getType())
+                        .name(i.getName())
+                        .token(i.getToken())
+                        .build())
+                .toList();
+    }
+
+    public DocContent createDocument(String title, String folderToken) throws Exception {
+        CreateDocumentReqBody reqBody = CreateDocumentReqBody.newBuilder()
+                .title(title)
+                .folderToken(folderToken)
+                .build();
+
+        CreateDocumentReq req = CreateDocumentReq.newBuilder()
+                .createDocumentReqBody(reqBody)
+                .build();
+
+        CreateDocumentResp resp = docxService.document().create(req);
+
+        // 创建请求对象
+        PatchPermissionPublicReq patchPermissionPublicReq = PatchPermissionPublicReq.newBuilder()
+                .permissionPublicRequest(PermissionPublicRequest.newBuilder()
+                        .externalAccess(true)
+                        .securityEntity("anyone_can_view")
+                        .commentEntity("anyone_can_view")
+                        .shareEntity("anyone")
+                        .linkShareEntity("tenant_editable")
+                        .inviteExternal(true)
+                        .build())
+                .build();
+
+        driveService.permissionPublic().patch(patchPermissionPublicReq);
+
+        return new DocContent()
+                .setDocumentId(resp.getData().getDocument().getDocumentId())
+                .setTitle(title)
+                .setFolderToken(folderToken);
+    }
+
+    public DocBlock createDocumentBlock(DocBlock block) throws Exception {
+        // 1. 获取文档的根块
+        ListDocumentBlockReq listReq = ListDocumentBlockReq.newBuilder()
+                .documentId(block.getDocId())
+                .build();
+        ListDocumentBlockResp listResp = docxService.documentBlock().list(listReq);
+
+        Block[] items = listResp.getData().getItems();
+        Block root = items[0];
+        block.setParentId(root.getBlockId());
+        if (listResp.getData().getItems() == null) {
+            throw new IllegalStateException("No blocks found in document");
+        }
+
+
+        // 2. 创建新块
+        Block[] feishuBlocks = block.toFeishuBlocks();
+
+        CreateDocumentBlockChildrenReqBody reqBody = CreateDocumentBlockChildrenReqBody.newBuilder()
+                .children(feishuBlocks)
+                .build();
+
+        CreateDocumentBlockChildrenReq createReq = CreateDocumentBlockChildrenReq.newBuilder()
+                .documentId(block.getDocId())
+                .blockId(block.getParentId())
+                .createDocumentBlockChildrenReqBody(reqBody)
+                .build();
+
+        CreateDocumentBlockChildrenResp createResp = docxService.documentBlockChildren().create(createReq);
+        if (!createResp.success()) {
+            throw new IllegalStateException("Failed to create document block: " + createResp.getMsg());
+        }
+        return block;
+    }
+
+
+    public DocContent getDocument(String documentId) throws Exception {
+        GetDocumentReq req = GetDocumentReq.newBuilder()
+                .documentId(documentId)
+                .build();
+
+        GetDocumentResp resp = docxService.document().get(req);
+        Document doc = resp.getData().getDocument();
+
+        return new DocContent()
+                .setDocumentId(doc.getDocumentId())
+                .setTitle(doc.getTitle());
+
+    }
+
+    public Files getFileInfo(String documentId) throws Exception {
+        List<Files> files = getDocumentFiles();
+        return files.stream()
+                .filter(file -> file.getToken().equals(documentId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("File not found with documentId: " + documentId));
+    }
+
+} 

--- a/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/util/FeishuHttpClient.java
+++ b/jcommon/mcp/mcp-feishu/src/main/java/run/mone/mcp/feishu/util/FeishuHttpClient.java
@@ -1,0 +1,130 @@
+package run.mone.mcp.feishu.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+public class FeishuHttpClient {
+    private final String appId;
+    private final String appSecret;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private String accessToken;
+    private long tokenExpireTime;
+
+    private static final String BASE_URL = "https://open.feishu.cn/open-apis";
+
+    public FeishuHttpClient(String appId, String appSecret) {
+        this.appId = appId;
+        this.appSecret = appSecret;
+        this.restTemplate = new RestTemplate();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public Map<String, Object> post(String path, Map<String, Object> body) throws Exception {
+        ensureAccessToken();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                BASE_URL + path,
+                HttpMethod.POST,
+                requestEntity,
+                Map.class
+        );
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new Exception("API request failed with status: " + response.getStatusCode());
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseBody = response.getBody();
+        if (responseBody == null || !responseBody.containsKey("code") || !Integer.valueOf(0).equals(responseBody.get("code"))) {
+            throw new Exception("API request failed: " + responseBody);
+        }
+
+        return responseBody;
+    }
+
+    // 给我写一个get请求
+    public Map<String, Object> get(String path, Map<String, String> queryParams) throws Exception {
+        ensureAccessToken();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(BASE_URL + path);
+        if (queryParams != null) {
+            queryParams.forEach(builder::queryParam);
+        }
+
+        HttpEntity<?> requestEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                builder.toUriString(),
+                HttpMethod.GET,
+                requestEntity,
+                Map.class
+        );
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new Exception("API request failed with status: " + response.getStatusCode());
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseBody = response.getBody();
+        if (responseBody == null || !responseBody.containsKey("code") || !Integer.valueOf(0).equals(responseBody.get("code"))) {
+            throw new Exception("API request failed: " + responseBody);
+        }
+
+        return responseBody;
+    }
+
+
+    private void ensureAccessToken() throws Exception {
+        if (accessToken != null && System.currentTimeMillis() < tokenExpireTime) {
+            return;
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> body = Map.of(
+                "app_id", appId,
+                "app_secret", appSecret
+        );
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                BASE_URL + "/auth/v3/tenant_access_token/internal",
+                HttpMethod.POST,
+                requestEntity,
+                Map.class
+        );
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new Exception("Failed to get access token");
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseBody = response.getBody();
+        if (responseBody == null || !responseBody.containsKey("tenant_access_token")) {
+            throw new Exception("Invalid token response");
+        }
+
+        accessToken = (String) responseBody.get("tenant_access_token");
+        int expireIn = ((Number) responseBody.get("expire")).intValue();
+        tokenExpireTime = System.currentTimeMillis() + (expireIn - 60) * 1000L; // 提前60秒过期
+    }
+} 

--- a/jcommon/mcp/mcp-feishu/src/main/resources/application.properties
+++ b/jcommon/mcp/mcp-feishu/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+stdio.enabled=true
+spring.main.web-application-type=none
+server.port=98991

--- a/jcommon/mcp/mcp-feishu/src/test/java/run/mone/mcp/feishu/function/FeishuDocFunctionTest.java
+++ b/jcommon/mcp/mcp-feishu/src/test/java/run/mone/mcp/feishu/function/FeishuDocFunctionTest.java
@@ -1,0 +1,193 @@
+package run.mone.mcp.feishu.function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.lark.oapi.service.docx.v1.enums.BlockTypeEnum;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import run.mone.hive.mcp.spec.McpSchema;
+import run.mone.mcp.feishu.model.*;
+import run.mone.mcp.feishu.service.FeishuDocService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@Slf4j
+class FeishuDocFunctionTest {
+
+    @Mock
+    private FeishuDocService docService;
+
+    private FeishuDocFunction feishuDocFunction;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        objectMapper = new ObjectMapper();
+        docService = new FeishuDocService();
+        feishuDocFunction = new FeishuDocFunction(docService, objectMapper);
+    }
+
+
+    @Test
+    void testMcp() {
+        Gson gson = new Gson();
+        // 准备请求参数
+        Map<String, Object> args = new HashMap<>();
+        args.put("operation", "createDocument");
+        args.put("title", "mcp333");
+
+        // 创建文件
+        McpSchema.CallToolResult result = feishuDocFunction.apply(args);
+        McpSchema.TextContent first = (McpSchema.TextContent) result.content().get(0);
+
+        DocContent docContent = gson.fromJson(first.text(), DocContent.class);
+
+        String documentId = docContent.getDocumentId();
+
+        // 准备请求参数
+        Map<Integer, String> elements = Map.of(2, "测试内容");
+
+        Map<String, Object> addBlock = new HashMap<>();
+        addBlock.put("operation", "addBlock");
+        addBlock.put("block", Map.of(
+                "docId", documentId, "elements", elements
+        ));
+        // 执行测试
+        McpSchema.CallToolResult addBlockRes = feishuDocFunction.apply(addBlock);
+
+        Map<String, Object> getFilesArg = new HashMap<>();
+        getFilesArg.put("operation", "getFiles");
+        McpSchema.CallToolResult files = feishuDocFunction.apply(getFilesArg);
+        McpSchema.TextContent content = (McpSchema.TextContent) files.content().get(0);
+        List<Files> filesList = gson.fromJson(content.text(), new TypeToken<List<Files>>() {
+        });
+        List<Files> list = filesList.stream().filter(file -> file.getToken().equals(documentId)).toList();
+
+        System.out.println(list);
+
+    }
+
+    @Test
+    void testCreateDocument() throws Exception {
+        // 准备请求参数
+        Map<String, Object> createDoc = new HashMap<>();
+        createDoc.put("operation", "createDocument");
+        createDoc.put("title", "测试文档1");
+
+        // 执行测试
+        McpSchema.CallToolResult result = feishuDocFunction.apply(createDoc);
+
+    }
+
+    @Test
+    void testAddBlock() throws Exception {
+        // 准备请求参数
+        Map<String, Object> args = new HashMap<>();
+        args.put("operation", "addBlock");
+        args.put("documentId", "doc_123");
+        args.put("block", Map.of(
+                "blockType", "text",
+                "content", Map.of("text", "测试内容")
+        ));
+
+        // 执行测试
+        McpSchema.CallToolResult result = feishuDocFunction.apply(args);
+
+        // 验证结果
+        assertNotNull(result);
+        assertFalse(result.isError());
+    }
+
+    @Test
+    void testUpdateBlock() throws Exception {
+        // 准备请求参数
+        Map<String, Object> args = new HashMap<>();
+        args.put("operation", "updateBlock");
+        args.put("documentId", "doc_123");
+        args.put("block", Map.of(
+                "blockId", "block_123",
+                "blockType", "text",
+                "content", Map.of("text", "更新的内容")
+        ));
+
+        // 执行测试
+        McpSchema.CallToolResult result = feishuDocFunction.apply(args);
+
+        // 验证结果
+        assertNotNull(result);
+        assertFalse(result.isError());
+    }
+
+    @Test
+    void testSetPermission() throws Exception {
+        // 准备请求参数
+        Map<String, Object> args = new HashMap<>();
+        args.put("operation", "setPermission");
+        args.put("permission", Map.of(
+                "documentId", "doc_123",
+                "userId", "user_123",
+                "userType", "user",
+                "perm", "edit"
+        ));
+
+        // 执行测试
+        McpSchema.CallToolResult result = feishuDocFunction.apply(args);
+
+        // 验证结果
+        assertNotNull(result);
+        assertFalse(result.isError());
+    }
+
+    @Test
+    void testGetDocument() throws Exception {
+        // 准备测试数据
+        DocContent mockDoc = new DocContent()
+                .setDocumentId("doc_123")
+                .setTitle("测试文档")
+                .setCreateTime(1234567890L)
+                .setUpdateTime(1234567890L)
+                .setCreator("user_123")
+                .setOwner("user_123");
+
+        // 设置mock行为
+        when(docService.getDocument(anyString())).thenReturn(mockDoc);
+
+        // 准备请求参数
+        Map<String, Object> args = new HashMap<>();
+        args.put("operation", "getDocument");
+        args.put("documentId", "doc_123");
+
+        // 执行测试
+        McpSchema.CallToolResult result = feishuDocFunction.apply(args);
+
+        // 验证结果
+        assertNotNull(result);
+        assertFalse(result.isError());
+    }
+
+    @Test
+    void testInvalidOperation() {
+        // 准备请求参数
+        Map<String, Object> args = new HashMap<>();
+        args.put("operation", "invalidOperation");
+
+        // 执行测试
+        McpSchema.CallToolResult result = feishuDocFunction.apply(args);
+
+        // 验证结果
+        assertNotNull(result);
+        assertTrue(result.isError());
+    }
+} 


### PR DESCRIPTION
- Add Feishu document base service (FeishuDocService)
- Implement core features for doc creation, editing and permission management
- Integrate with Feishu Open API for document operations
- Add unit tests to ensure functionality